### PR TITLE
Add Claude Code hooks and project documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "intercept",
+            "command": "python -c \"import sys,json; d=json.load(sys.stdin); p=d.get('file_path',''); blocked=['.env','secrets','.git/']; sys.exit(1) if any(x in p for x in blocked) else sys.exit(0)\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -c \"import sys,json; d=json.load(sys.stdin); p=d.get('file_path',''); exec('import subprocess; r=subprocess.run([sys.executable,\\\"-m\\\",\\\"py_compile\\\",p],capture_output=True,text=True); print(r.stderr) if r.returncode else print(\\\"Syntax OK: \\\"+p)') if p.endswith('.py') else print('Skipped (not Python)')\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# ClawCloud Auto-Login
+
+Automated ClawCloud keep-alive via GitHub Actions + Playwright.
+
+## Commands
+
+```bash
+# Install dependencies
+pip install playwright requests pynacl
+playwright install chromium
+playwright install-deps
+
+# Run locally
+python scripts/auto_login.py
+```
+
+## Architecture
+
+- `scripts/auto_login.py` — Single-file automation script (Playwright browser automation)
+- `.github/workflows/keep-alive.yml` — Cron job (every 5 days, UTC 01:00)
+- `.claude/settings.json` — Claude Code hooks
+
+## Key Classes (auto_login.py)
+
+- `Telegram` — Bot notifications and 2FA code retrieval via `/code` command
+- `SecretUpdater` — Auto-updates GitHub Secrets via API (requires PyNaCl)
+- `AutoLogin` — Main login flow: ClawCloud → GitHub OAuth → region detection → keepalive
+
+## Required Secrets
+
+`GH_USERNAME`, `GH_PASSWORD`, `GH_SESSION`, `TG_BOT_TOKEN`, `TG_CHAT_ID`, `REPO_TOKEN`
+
+## Gotchas
+
+- All credentials come from GitHub Actions secrets / environment variables — never hardcode
+- The script uses anti-detection measures (custom user agent, webdriver override)
+- `GH_SESSION` cookie auto-updates on successful login if `REPO_TOKEN` is set
+- Region is auto-detected from redirect URL after OAuth (e.g. `ap-southeast-1.console.claw.cloud`)
+- 2FA supports both GitHub Mobile approval and TOTP via Telegram `/code 123456`


### PR DESCRIPTION
## Summary
- Add PreToolUse hook to block edits to sensitive files (`.env`, `secrets`, `.git/`)
- Add PostToolUse hook to auto-lint Python files with `py_compile` on save
- Add `CLAUDE.md` documenting commands, architecture, secrets, and gotchas

## Test plan
- [ ] Verify PreToolUse hook blocks edits to files with `.env`, `secrets`, or `.git/` in the path
- [ ] Verify PostToolUse hook runs `py_compile` after editing `.py` files and reports syntax errors
- [ ] Verify non-Python files are skipped by the PostToolUse hook
- [ ] Verify `CLAUDE.md` content matches current project structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)